### PR TITLE
`<memory/allocator>`: Add missing `[[nodiscard]]` attribute

### DIFF
--- a/src/bstk/memory/allocator.hpp
+++ b/src/bstk/memory/allocator.hpp
@@ -43,7 +43,7 @@ namespace bs {
         virtual bool is_equal(const allocator& _Other) const noexcept = 0;
 
         // allocates uninitialized storage with optional alignment
-        virtual pointer allocate(size_type _Size, size_type _Align = 0) = 0;
+        [[nodiscard]] virtual pointer allocate(size_type _Size, size_type _Align = 0) = 0;
 
         // deallocates storage with optional alignment
         virtual void deallocate(pointer _Ptr, size_type _Size, size_type _Align) = 0;

--- a/src/bstk/memory/object_allocator.hpp
+++ b/src/bstk/memory/object_allocator.hpp
@@ -62,7 +62,7 @@ namespace bs {
             return ::bs::get_allocator().is_equal(_Other);
         }
 
-        pointer allocate(const size_type _Count, const size_type _Align = 0) {
+        [[nodiscard]] pointer allocate(const size_type _Count, const size_type _Align = 0) {
             return static_cast<pointer>(
                 ::bs::get_allocator().allocate(_Count * sizeof(_Ty), _Choose_align(_Align)));
         }

--- a/src/bstk/memory/system_allocator.hpp
+++ b/src/bstk/memory/system_allocator.hpp
@@ -37,7 +37,7 @@ namespace bs {
         bool is_equal(const allocator& _Other) const noexcept override;
 
         // allocates uninitialized storage with optional alignment
-        pointer allocate(size_type _Size, size_type _Align = 0) override;
+        [[nodiscard]] pointer allocate(size_type _Size, size_type _Align = 0) override;
 
         // deallocates storage with optional alignment
         void deallocate(pointer _Ptr, size_type _Size, size_type _Align) override;

--- a/tests/src/memory/allocator/test.cpp
+++ b/tests/src/memory/allocator/test.cpp
@@ -4,6 +4,7 @@
 // Licensed under BSDL 1.0
 
 #include <bstk/memory/allocator.hpp>
+#include <bstk/memory/system_allocator.hpp>
 #include <gtest/gtest.h>
 
 namespace bs {
@@ -29,7 +30,7 @@ namespace bs {
             return false;
         }
 
-        pointer allocate(size_type, size_type) override {
+        [[nodiscard]] pointer allocate(size_type, size_type) override {
             return nullptr;
         }
 
@@ -64,16 +65,24 @@ namespace bs {
             return false;
         }
 
-        pointer allocate(size_type, size_type) {
+        [[nodiscard]] pointer allocate(size_type, size_type) {
             return nullptr;
         }
 
         void deallocate(pointer, size_type, size_type) {}
     };
 
+    TEST(any_allocator, standard_allocator) {
+        EXPECT_TRUE(any_allocator<system_allocator>);
+    }
+
     TEST(any_allocator, custom_allocator) {
         EXPECT_TRUE(any_allocator<_Valid_allocator>);
         EXPECT_FALSE(any_allocator<_Invalid_allocator>);
+    }
+
+    TEST(is_allocator, standard_allocator) {
+        EXPECT_TRUE(is_allocator<system_allocator>::value);
     }
 
     TEST(is_allocator, custom_allocator) {

--- a/tests/src/memory/object_allocator/test.cpp
+++ b/tests/src/memory/object_allocator/test.cpp
@@ -34,7 +34,7 @@ namespace bs {
             return true;
         }
 
-        pointer allocate(size_type _Size, size_type _Align) override {
+        [[nodiscard]] pointer allocate(size_type _Size, size_type _Align) override {
             _Capture_allocation_size(_Size, _Align);
             return nullptr;
         }

--- a/tests/src/memory/system_allocator/test.cpp
+++ b/tests/src/memory/system_allocator/test.cpp
@@ -7,23 +7,25 @@
 #include <gtest/gtest.h>
 
 namespace bs {
-    TEST(system_allocator, allocate_aligned) {
-        constexpr size_t _Count = 1000;
-        constexpr size_t _Align = 64;
+    class system_allocator_test : public ::testing::Test {
+    protected:
         system_allocator _Al;
+    };
+
+    TEST_F(system_allocator_test, allocate_aligned) {
+        constexpr size_t _Count    = 1000;
+        constexpr size_t _Align    = 64;
         void* const _Ptr           = _Al.allocate(_Count, _Align);
         const uintptr_t _Ptr_bytes = reinterpret_cast<uintptr_t>(_Ptr);
         EXPECT_EQ(_Ptr_bytes % _Align, 0); // address should also be aligned
         _Al.deallocate(_Ptr, _Count, _Align);
     }
 
-    TEST(system_allocator, id) {
-        const system_allocator _Al;
+    TEST_F(system_allocator_test, id) {
         EXPECT_EQ(_Al.id(), allocator_id::system);
     }
 
-    TEST(system_allocator, max_size) {
-        const system_allocator _Al;
+    TEST_F(system_allocator_test, max_size) {
 #if _BS_X64
         EXPECT_EQ(_Al.max_size(), 0xFFFF'FFFF'FFFF'FFFF);
 #else // ^^^ _BS_X64 ^^^ / vvv _BS_X86 vvv
@@ -31,10 +33,9 @@ namespace bs {
 #endif // _BS_X64
     }
 
-    TEST(system_allocator, is_equal) {
-        const system_allocator _Al0;
-        const system_allocator _Al1;
-        EXPECT_TRUE(_Al0.is_equal(_Al1));
-        EXPECT_TRUE(_Al1.is_equal(_Al0));
+    TEST_F(system_allocator_test, is_equal) {
+        const system_allocator _Al2;
+        EXPECT_TRUE(_Al.is_equal(_Al2));
+        EXPECT_TRUE(_Al2.is_equal(_Al));
     }
 } // namespace bs


### PR DESCRIPTION
Resolves #69